### PR TITLE
Use all cores when building.

### DIFF
--- a/Formula/yosys.rb
+++ b/Formula/yosys.rb
@@ -1,4 +1,5 @@
 class Yosys < Formula
+  include Hardware
   desc "Framework for Verilog RTL synthesis"
   homepage "http://www.clifford.at/yosys/"
   url "https://github.com/YosysHQ/yosys/archive/yosys-0.9.tar.gz"
@@ -19,7 +20,7 @@ class Yosys < Formula
   depends_on "readline"
 
   def install
-    system "make", "install", "PREFIX=#{prefix}", "PRETTY=0"
+    system "make", "install", "PREFIX=#{prefix}", "PRETTY=0", "-j#{CPU.cores}"
   end
 
   test do


### PR DESCRIPTION
yosys.rb takes a while to build from source as it only currently uses one job.
Now it can use as many jobs as there are cores.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
